### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,7 @@ class ItemsController < ApplicationController
   before_action :set_item, only: [:show, :edit, :update]
   def index
     # 登録が新しい順で取得
-    @items = Item.order("created_at DESC")
+    @items = Item.order('created_at DESC')
   end
 
   def new
@@ -23,9 +23,7 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    unless current_user.id == @item.user_id
-      redirect_to root_path
-    end
+    redirect_to root_path unless current_user.id == @item.user_id
   end
 
   def update
@@ -36,6 +34,13 @@ class ItemsController < ApplicationController
     end
   end
 
+  def destroy
+    item = Item.find(params[:id])
+    if user_signed_in? && current_user.id = item.user_id
+      item.destroy
+      redirect_to root_path
+    end
+  end
 
   private
 
@@ -47,5 +52,4 @@ class ItemsController < ApplicationController
   def set_item
     @item = Item.find(params[:id])
   end
-
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -36,7 +36,7 @@ class ItemsController < ApplicationController
 
   def destroy
     item = Item.find(params[:id])
-    if user_signed_in? && current_user.id = item.user_id
+    if user_signed_in? && current_user.id == item.user_id
       item.destroy
       redirect_to root_path
     end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -13,7 +13,9 @@ class Item < ApplicationRecord
     validates :title
     validates :description
     validates :image
-    validates :price, numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999, only_integer: true, allow_blank: true }
+    validates :price,
+              numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999, only_integer: true,
+                              allow_blank: true }
   end
 
   with_options numericality: { other_than: 1, message: "can't be blank" } do

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -30,7 +30,7 @@
       <% if current_user.id == @item.user_id %>
         <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+        <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
 
       <%# ログインしているユーザーと商品の出品をしたユーザーが異なる場合に表示 %>
       <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:new, :create, :show, :edit, :update]
+  resources :items, only: [:new, :create, :show, :edit, :update, :destroy]
 end


### PR DESCRIPTION
# What
- itemモデル、及び関連するActiveHashの作成
- ルーティングの追加

# Why
商品出削除能実装のため。

## Gyazo URL
- ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる
https://i.gyazo.com/305e2af4b18b61d0bbac2e99baa030bf.gif
